### PR TITLE
[Calendar update fixed] Reuse and dependency-inject Calendar

### DIFF
--- a/java/com/scrat/everchanging/BackgroundScene.java
+++ b/java/com/scrat/everchanging/BackgroundScene.java
@@ -5,6 +5,8 @@ import java.util.Calendar;
 
 public class BackgroundScene extends Scene {
 
+    private final Calendar calendar;
+
     private final Background background;
     private final Foreground foreground;
 
@@ -12,14 +14,14 @@ public class BackgroundScene extends Scene {
     private int currentForeground;
     private int currentTimesOfDay;
 
-    BackgroundScene (Context context) {
+    BackgroundScene (final Context context, final Calendar calendar) {
         super(ShortTypes.BG);
+        this.calendar = calendar;
         background = new Background(context);
         foreground = new Foreground(context);
     }
 
     private void GetDateTime(){
-        Calendar calendar = Calendar.getInstance();
         int currentMonth = calendar.get(Calendar.MONTH) + 1;
         int currentDay = calendar.get(Calendar.DAY_OF_MONTH);
         int currentHour = calendar.get(Calendar.HOUR_OF_DAY);

--- a/java/com/scrat/everchanging/ButterFlie.java
+++ b/java/com/scrat/everchanging/ButterFlie.java
@@ -1008,14 +1008,17 @@ public class ButterFlie extends TextureObject {
 
     private final float[] animationStartPosition = {1.0f, 1.0f, 0.0000f, 0.0000f, 3.40f, -3.60f};
 
+    private final Calendar calendar;
+
     ArrayList<Object> removeObjects = new ArrayList<>();
     boolean init = false;
     float svgScale = 1.0f;
     int frameCounter = 0;
     int maxFrames = 10;
     int numClips = minObjects;
-    ButterFlie(Context context) {
+    ButterFlie(Context context, final Calendar calendar) {
         super(context, textureList, null);
+        this.calendar = calendar;
     }
     private int ConvertRange(
             int originalStart, int originalEnd, // original range
@@ -1027,7 +1030,6 @@ public class ButterFlie extends TextureObject {
     }
     private boolean get2401() {
         svgScale = textureManager.dipToPixels(1);
-        Calendar calendar = Calendar.getInstance();
         int currentMonth = calendar.get(Calendar.MONTH) + 1;
         int currentDay = calendar.get(Calendar.DAY_OF_MONTH);
         return (currentMonth==1) && (currentDay==24);

--- a/java/com/scrat/everchanging/ButterFliesScene.java
+++ b/java/com/scrat/everchanging/ButterFliesScene.java
@@ -2,11 +2,13 @@ package com.scrat.everchanging;
 
 import android.content.Context;
 
+import java.util.Calendar;
+
 public class ButterFliesScene extends Scene {
     private final ButterFlie butterflie;
-    public ButterFliesScene(Context context) {
+    public ButterFliesScene(final Context context, final Calendar calendar) {
         super(ShortTypes.B);
-        butterflie = new ButterFlie(context);
+        butterflie = new ButterFlie(context, calendar);
     }
 
     public void update(boolean createObject) {

--- a/java/com/scrat/everchanging/Dandelion.java
+++ b/java/com/scrat/everchanging/Dandelion.java
@@ -234,6 +234,8 @@ public class Dandelion extends TextureObject {
     };
     private final float[] animationStartPosition = {0.15f, 0.15f, 0.0000f, 0.0000f, 38.55f, 24.85f};
 
+    private final Calendar calendar;
+
     ArrayList<Object> removeObjects = new ArrayList<>();
 
     int frameCounter = 0;
@@ -241,8 +243,9 @@ public class Dandelion extends TextureObject {
     int numClips = minObjects;
     boolean init = false;
     float svgScale = 1.0f;
-    public Dandelion(Context context) {
+    public Dandelion(Context context, final Calendar calendar) {
         super(context, textureList, pivotList);
+        this.calendar = calendar;
     }
 
     void createObject() {
@@ -267,7 +270,6 @@ public class Dandelion extends TextureObject {
 
     private boolean get1902() {
         svgScale = textureManager.dipToPixels(1);
-        Calendar calendar = Calendar.getInstance();
         int currentMonth = calendar.get(Calendar.MONTH) + 1;
         int currentDay = calendar.get(Calendar.DAY_OF_MONTH);
         return (currentMonth==2) && (currentDay==19);

--- a/java/com/scrat/everchanging/DandelionsScene.java
+++ b/java/com/scrat/everchanging/DandelionsScene.java
@@ -2,13 +2,15 @@ package com.scrat.everchanging;
 
 import android.content.Context;
 
+import java.util.Calendar;
+
 public class DandelionsScene extends Scene {
 
     private final Dandelion dandelion;
 
-    public DandelionsScene(Context context) {
+    public DandelionsScene(final Context context, final Calendar calendar) {
         super(ShortTypes.D);
-        dandelion = new Dandelion(context);
+        dandelion = new Dandelion(context, calendar);
     }
 
     public void update(boolean createObject) {

--- a/java/com/scrat/everchanging/EverchangingRender.java
+++ b/java/com/scrat/everchanging/EverchangingRender.java
@@ -112,9 +112,21 @@ public class EverchangingRender implements GLSurfaceView.Renderer {
         {10, 2, 9, 9, 8, 9, 8, 8, 9, 9, 9, 8, 8,  8, 9,  8, 8, 7, 8, 10, 3, 3, 10,  3,  3, 3, 3, 0, 0,  0,  9}
     };
 
-    Context context;
+    private static final int UPDATE_COUNT_TO_RECOMPUTE_TIME = 800;
+
+    private final Calendar calendar = Calendar.getInstance();
+
+    private final Context context;
 
     private final ArrayList<Scene> scenes = new ArrayList<>();
+
+    /**
+     * Optimization not to recompute time in Calendar on every {@link #update}.
+     * <br/><br/>
+     * As updateCounter reaches {@link #UPDATE_COUNT_TO_RECOMPUTE_TIME}, then time will be
+     * recalculated and updateCounter reset
+     */
+    private int updateCounter;
 
     public EverchangingRender(Context context) {
         this.context = context;
@@ -132,19 +144,19 @@ public class EverchangingRender implements GLSurfaceView.Renderer {
         GLES20.glBlendFunc(GLES20.GL_SRC_ALPHA, GLES20.GL_ONE_MINUS_SRC_ALPHA);
 
 
-        scenes.add(new BackgroundScene(context));
+        scenes.add(new BackgroundScene(context, calendar));
         scenes.add(new CrystalBlickScene(context));
-        scenes.add(new FireFliesScene(context));
-        scenes.add(new DandelionsScene(context));
-        scenes.add(new RainsScene(context));
+        scenes.add(new FireFliesScene(context, calendar));
+        scenes.add(new DandelionsScene(context, calendar));
+        scenes.add(new RainsScene(context, calendar));
         scenes.add(new PetalsScene(context));
-        scenes.add(new SnowsScene(context));
-        scenes.add(new LeavesScene(context));
-        scenes.add(new FireWorksScene(context));
-        scenes.add(new EyesScene(context));
-        scenes.add(new ButterFliesScene(context));
+        scenes.add(new SnowsScene(context, calendar));
+        scenes.add(new LeavesScene(context, calendar));
+        scenes.add(new FireWorksScene(context, calendar));
+        scenes.add(new EyesScene(context, calendar));
+        scenes.add(new ButterFliesScene(context, calendar));
         scenes.add(new BatsScene(context));
-        scenes.add(new HeartsScene(context));
+        scenes.add(new HeartsScene(context, calendar));
         scenes.add(new ValentinesScene(context));
         scenes.add(new FairiesScene(context));
 
@@ -185,7 +197,6 @@ public class EverchangingRender implements GLSurfaceView.Renderer {
 
 
     private Scene.ShortTypes getAnim() {
-        Calendar calendar = Calendar.getInstance();
         int currentMonth = calendar.get(Calendar.MONTH);
         int currentDay = calendar.get(Calendar.DAY_OF_MONTH)-1;
         int currentHour = calendar.get(Calendar.HOUR_OF_DAY);
@@ -217,6 +228,12 @@ public class EverchangingRender implements GLSurfaceView.Renderer {
                     case F: ((FairiesScene) scene).update(createObject); break;
                 }
             }
+
+        updateCounter++;
+        if (updateCounter == UPDATE_COUNT_TO_RECOMPUTE_TIME) {
+            updateCounter = 0;
+            calendar.setTimeInMillis(System.currentTimeMillis());
+        }
     }
 
     void render(){

--- a/java/com/scrat/everchanging/Eye.java
+++ b/java/com/scrat/everchanging/Eye.java
@@ -21,14 +21,16 @@ public class Eye extends TextureObject {
     boolean init = false;
     static final String[][] textureList = {{"image_1","image_2","image_3","image_4","image_5","image_6","image_7","image_8","image_9","image_10","image_11","image_12"}};
 
+    private final Calendar calendar;
+
     boolean[] positions = {false,false,false,false,false};
     ArrayList<Object> removeObjects = new ArrayList<>();
-    public Eye(Context context) {
+    public Eye(final Context context, final Calendar calendar) {
         super(context, textureList, null);
+        this.calendar = calendar;
     }
 
     private boolean get0601() {
-        Calendar calendar = Calendar.getInstance();
         int currentMonth = calendar.get(Calendar.MONTH) + 1;
         int currentDay = calendar.get(Calendar.DAY_OF_MONTH);
         return (currentMonth==1) && (currentDay==6);

--- a/java/com/scrat/everchanging/EyesScene.java
+++ b/java/com/scrat/everchanging/EyesScene.java
@@ -2,12 +2,14 @@ package com.scrat.everchanging;
 
 import android.content.Context;
 
+import java.util.Calendar;
+
 public class EyesScene extends Scene {
 
     private final Eye eye;
-    public EyesScene(Context context) {
+    public EyesScene(final Context context, final Calendar calendar) {
         super(ShortTypes.E);
-        eye = new Eye(context);
+        eye = new Eye(context, calendar);
     }
 
     public void update(boolean createObject) {

--- a/java/com/scrat/everchanging/FireFlie.java
+++ b/java/com/scrat/everchanging/FireFlie.java
@@ -145,12 +145,15 @@ public class FireFlie extends TextureObject {
     int maxFrames = 6;
     boolean init = false;
 
+    private final Calendar calendar;
+
     static final String[][] textureList = {{"image_168","image_170"}};
     static final float[][] pivotList = {{7.5f, 7.5f},{7.5f, 7.5f}};
     ArrayList<Object> removeObjects = new ArrayList<>();
 
-    public FireFlie(Context context) {
+    public FireFlie(final Context context, final Calendar calendar) {
         super(context, textureList, pivotList);
+        this.calendar = calendar;
     }
 
     void createObject() {
@@ -198,7 +201,6 @@ public class FireFlie extends TextureObject {
     }
 
     private boolean get2501() {
-        Calendar calendar = Calendar.getInstance();
         int currentMonth = calendar.get(Calendar.MONTH) + 1;
         int currentDay = calendar.get(Calendar.DAY_OF_MONTH);
         return (currentMonth==1) && (currentDay==25);

--- a/java/com/scrat/everchanging/FireFliesScene.java
+++ b/java/com/scrat/everchanging/FireFliesScene.java
@@ -2,13 +2,15 @@ package com.scrat.everchanging;
 
 import android.content.Context;
 
+import java.util.Calendar;
+
 public class FireFliesScene extends Scene {
 
     private final FireFlie fireflie;
 
-    public FireFliesScene(Context context) {
+    public FireFliesScene(final Context context, final Calendar calendar) {
         super(ShortTypes.FF);
-        fireflie = new FireFlie(context);
+        fireflie = new FireFlie(context, calendar);
     }
 
     public void update(boolean createObject) {

--- a/java/com/scrat/everchanging/FireWork.java
+++ b/java/com/scrat/everchanging/FireWork.java
@@ -33,17 +33,19 @@ public class FireWork extends TextureObject{
     int maxFrames = 5;
     ArrayList<Object> removeObjects = new ArrayList<>();
 
+    private final Calendar calendar;
+
     private boolean get010104() {
         svgScale = textureManager.dipToPixels(1);
-        Calendar calendar = Calendar.getInstance();
         int currentMonth = calendar.get(Calendar.MONTH) + 1;
         int currentDay = calendar.get(Calendar.DAY_OF_MONTH);
         int currentYear = calendar.get(Calendar.YEAR);
         return (currentMonth==1) && (currentDay==1) && (currentYear % 4 == 0);
     }
 
-    FireWork(Context context) {
+    FireWork(final Context context, final Calendar calendar) {
         super(context, textureList, null);
+        this.calendar = calendar;
     }
 
     void resetObject(Object object) {

--- a/java/com/scrat/everchanging/FireWorksScene.java
+++ b/java/com/scrat/everchanging/FireWorksScene.java
@@ -1,11 +1,14 @@
 package com.scrat.everchanging;
 
 import android.content.Context;
+
+import java.util.Calendar;
+
 public class FireWorksScene extends Scene{
     private final FireWork firework;
-    FireWorksScene(Context context) {
+    FireWorksScene(final Context context, final Calendar calendar) {
         super(ShortTypes.FW);
-        firework = new FireWork(context);
+        firework = new FireWork(context, calendar);
     }
     public void setupPosition(int width, int height, float ratio, int displayRotation) {
         super.createProjectMatrix(width, height, displayRotation);

--- a/java/com/scrat/everchanging/HeartsScene.java
+++ b/java/com/scrat/everchanging/HeartsScene.java
@@ -2,13 +2,15 @@ package com.scrat.everchanging;
 
 import android.content.Context;
 
+import java.util.Calendar;
+
 public class HeartsScene extends Scene implements Rain.FinishCallback {
     private final Rain rain;
     private final Ripple ripple;
 
-    public HeartsScene(Context context) {
+    public HeartsScene(final Context context, final Calendar calendar) {
         super(ShortTypes.H);
-        rain = new Rain(context, 1);
+        rain = new Rain(context, calendar, 1);
         ripple = new Ripple(context, 1);
         rain.registerCallBack(this);
     }

--- a/java/com/scrat/everchanging/Leave.java
+++ b/java/com/scrat/everchanging/Leave.java
@@ -380,6 +380,8 @@ public class Leave extends TextureObject {
             {{128, 128, 128, 256},{199, 168, 39, 0}}
     };
 
+    private final Calendar calendar;
+
     ArrayList<Object> removeObjects = new ArrayList<>();
     int frameCounter = 0;
     int maxFrames = 8;
@@ -388,14 +390,14 @@ public class Leave extends TextureObject {
     boolean init = false;
     int animCount =1;
 
-    public Leave (Context context) {
+    public Leave (final Context context, final Calendar calendar) {
         super(context, textureList, null);
+        this.calendar = calendar;
     }
 
     private boolean get0703() {
         svgScale = textureManager.dipToPixels(1);
         animCount = (int)((height / 280.0f) + 0.5f);
-        Calendar calendar = Calendar.getInstance();
         int currentMonth = calendar.get(Calendar.MONTH) + 1;
         int currentDay = calendar.get(Calendar.DAY_OF_MONTH);
         return (currentMonth==3) && (currentDay==7);

--- a/java/com/scrat/everchanging/LeavesScene.java
+++ b/java/com/scrat/everchanging/LeavesScene.java
@@ -1,11 +1,14 @@
 package com.scrat.everchanging;
 
 import android.content.Context;
+
+import java.util.Calendar;
+
 public class LeavesScene extends Scene {
     private final Leave leave;
-    LeavesScene(Context context) {
+    LeavesScene(final Context context, final Calendar calendar) {
         super(ShortTypes.L);
-        leave = new Leave(context);
+        leave = new Leave(context, calendar);
     }
 
     public void setupPosition(int width, int height, float ratio, int displayRotation) {

--- a/java/com/scrat/everchanging/Rain.java
+++ b/java/com/scrat/everchanging/Rain.java
@@ -27,6 +27,8 @@ public class Rain extends TextureObject  {
 
     static final String[][] textureList = {{"shape_22"}};
 
+    private final Calendar calendar;
+
     ArrayList<Object> removeObjects = new ArrayList<>();
 
     int frameCounter = 0;
@@ -39,8 +41,9 @@ public class Rain extends TextureObject  {
     FinishCallback finishCallback;
     int typesAnim;
 
-    Rain(Context context, int anim) {
+    Rain(final Context context, final Calendar calendar, final int anim) {
         super(context, textureList, null);
+        this.calendar = calendar;
         this.typesAnim = anim;
     }
 
@@ -73,7 +76,6 @@ public class Rain extends TextureObject  {
 
     private boolean get0403() {
         frameMoveCount = 1 + (int) (height / speed);
-        Calendar calendar = Calendar.getInstance();
         int currentMonth = calendar.get(Calendar.MONTH) + 1;
         int currentDay = calendar.get(Calendar.DAY_OF_MONTH);
         return (currentMonth==3) && (currentDay==4);

--- a/java/com/scrat/everchanging/RainsScene.java
+++ b/java/com/scrat/everchanging/RainsScene.java
@@ -2,14 +2,16 @@ package com.scrat.everchanging;
 
 import android.content.Context;
 
-public class RainsScene extends Scene implements Rain.FinishCallback  {
+import java.util.Calendar;
+
+public class RainsScene extends Scene implements Rain.FinishCallback {
 
     private final Rain rain;
     private final Ripple ripple;
 
-    public RainsScene(Context context) {
+    public RainsScene(final Context context, final Calendar calendar) {
         super(ShortTypes.R);
-        rain = new Rain(context, 0);
+        rain = new Rain(context, calendar, 0);
         ripple = new Ripple(context, 0);
         rain.registerCallBack(this);
     }

--- a/java/com/scrat/everchanging/Snow.java
+++ b/java/com/scrat/everchanging/Snow.java
@@ -140,6 +140,7 @@ public class Snow extends TextureObject{
             {{256, 256, 256, 0}, {0, 0, 0, 0}}
     };
 
+    private final Calendar calendar;
 
     ArrayList<Object> removeObjects = new ArrayList<>();
     int frameCounter = 0;
@@ -148,13 +149,13 @@ public class Snow extends TextureObject{
     boolean init = false;
     int heightMax = 0;
 
-    public Snow (Context context) {
+    public Snow (final Context context, final Calendar calendar) {
         super(context, textureList,null);
+        this.calendar = calendar;
     }
 
     private boolean get0404() {
         heightMax = (int) (height * 0.5f) + colorTransform.length + 10;
-        Calendar calendar = Calendar.getInstance();
         int currentMonth = calendar.get(Calendar.MONTH) + 1;
         int currentDay = calendar.get(Calendar.DAY_OF_MONTH);
         return (currentMonth==4) && (currentDay==4);

--- a/java/com/scrat/everchanging/SnowsScene.java
+++ b/java/com/scrat/everchanging/SnowsScene.java
@@ -2,13 +2,15 @@ package com.scrat.everchanging;
 
 import android.content.Context;
 
+import java.util.Calendar;
+
 public class SnowsScene extends Scene{
 
     private final Snow show;
 
-    SnowsScene(Context context) {
+    SnowsScene(final Context context, final Calendar calendar) {
         super(ShortTypes.S);
-        show = new Snow(context);
+        show = new Snow(context, calendar);
     }
 
     public void setupPosition(int width, int height, float ratio, int displayRotation) {


### PR DESCRIPTION
This fixes #3

This is an amended commit that fixes time update issue.
Calendar will recompute time around every 40 seconds (every 800 frames assuming 20 fps).
Why 40 and not 60 seconds were chosen is to reduce possibility of being late by one minute for events like New Year.