### PR TITLE
Reuse objects in object pool

### DIFF
--- a/java/com/scrat/everchanging/Background.java
+++ b/java/com/scrat/everchanging/Background.java
@@ -1,7 +1,8 @@
 package com.scrat.everchanging;
 
 import android.content.Context;
-import android.util.Log;
+
+import com.scrat.everchanging.util.ReusableIterator;
 
 public class Background extends TextureObject {
     final float[][][][] colorTransformValues = {
@@ -38,21 +39,22 @@ public class Background extends TextureObject {
         int textureIndex = textureManager.getTextureIndex(textureList[0][season]);
         TextureManager.Texture texture = textureManager.getTexture(textureIndex);
 
-        if (!objects.isEmpty()) {
-            final int objectsSize = objects.size();
-            for (int i = 0; i < objectsSize; i++) {
-                objects.get(i).setTexture(texture, scale);
-            }
-        }
+        if (objects.objectsInUseCount() != 0) {
+            final ReusableIterator<Object> iterator = objects.iterator();
+            iterator.acquire();
 
-        else {
-            Object object = new Object(texture, scale);
+            while (iterator.hasNext()) {
+                iterator.next().setTexture(texture, scale);
+            }
+
+            iterator.release();
+        } else {
+            final Object object = objects.obtain(texture, scale);
             object.setObjectScale(1.0f);
             object.resetMatrix();
             object.resetViewMatrix();
             object.setScale(ratio, ratio); //Масштабируем по высоте, иначе не красиво.
             object.setTranslate(width - (object.texture.width) * scale * 0.5f * ratio, (object.texture.height)  * scale* 0.5f * ratio);
-            objects.add(object);
         }
     }
 
@@ -60,9 +62,13 @@ public class Background extends TextureObject {
         int s = season == 5 ? 4:season;
         if (currentSeason != s) createObject(s);
 
-        final int objectsSize = objects.size();
-        for (int i = 0; i < objectsSize; i++) {
-            objects.get(i).setColorTransform(colorTransformValues[season][timesOfDay]);
+        final ReusableIterator<Object> iterator = objects.iterator();
+        iterator.acquire();
+
+        while (iterator.hasNext()) {
+            iterator.next().setColorTransform(colorTransformValues[season][timesOfDay]);
         }
+
+        iterator.release();
     }
 }

--- a/java/com/scrat/everchanging/Bat.java
+++ b/java/com/scrat/everchanging/Bat.java
@@ -1,7 +1,8 @@
 package com.scrat.everchanging;
 
 import android.content.Context;
-import java.util.ArrayList;
+
+import com.scrat.everchanging.util.ReusableIterator;
 
 public class Bat extends TextureObject {
     static final String[][] textureList = {{"shape_49","shape_50","shape_51","shape_52"}};
@@ -118,8 +119,6 @@ public class Bat extends TextureObject {
             {3.431f, 3.432f, 0.0000f, 0.0000f, 2755.2f, 1152.7f}
     };
 
-    ArrayList<Object> removeObjects = new ArrayList<>();
-
     int maxFrames = 33;
     int frameCounter = 0;
     int numClips = 7;
@@ -141,9 +140,9 @@ public class Bat extends TextureObject {
         object.index = 0;
     }
     void createObject() {
-        if (objects.size() > numClips) return;
+        if (objects.objectsInUseCount() > numClips) return;
         int textureIndex = textureManager.getTextureIndex(textureList[0][0]);
-        Object object = new Object(textureManager.getTexture(textureIndex), 1.0f);
+        Object object = objects.obtain(textureManager.getTexture(textureIndex), 1.0f);
         float svgScale = textureManager.dipToPixels(1);
         object.setObjectScale(1.0f/svgScale);
         int _x = random.nextInt(50) + random.nextInt(600) - 300;
@@ -156,16 +155,17 @@ public class Bat extends TextureObject {
         object.frameCounter = 0;
         object.animCounter = 0;
         object.index = 0;
-        objects.add(object);
     }
 
     public void update(boolean createObject) {
         frameCounter = (frameCounter+1) % maxFrames;
         if (createObject && (frameCounter==2)) createObject();
 
-        final int objectsSize = objects.size();
-        for (int i = 0; i < objectsSize; i++) {
-            final Object object = objects.get(i);
+        final ReusableIterator<Object> iterator = objects.iterator();
+        iterator.acquire();
+
+        while (iterator.hasNext()) {
+            final Object object = iterator.next();
             if (object.frameCounter < matrixTransform.length) {
                 object.resetMatrix();
                 object.setTexture(textureManager.getTexture(textureManager.getTextureIndex(textureList[0][spriteTable[object.animCounter]])), 1.0f);
@@ -175,15 +175,11 @@ public class Bat extends TextureObject {
                 object.frameCounter++;
             } else {
                 if (createObject) resetObject(object);
-               else removeObjects.add(object);
+               else iterator.remove();
             }
         }
 
-        final int removeObjectsSize = removeObjects.size();
-        for (int i = 0; i < removeObjectsSize; i++) {
-            objects.remove(removeObjects.get(i));
-        }
-        removeObjects.clear();
+        iterator.release();
     }
 
 }

--- a/java/com/scrat/everchanging/Fairy.java
+++ b/java/com/scrat/everchanging/Fairy.java
@@ -2,6 +2,8 @@ package com.scrat.everchanging;
 
 import android.content.Context;
 
+import com.scrat.everchanging.util.ReusableIterator;
+
 import java.util.ArrayList;
 
 public class Fairy extends TextureObject {
@@ -10,7 +12,6 @@ public class Fairy extends TextureObject {
     }
 
     static final String[][] textureList = {{"image_15"}};
-    ArrayList<Object> removeObjects = new ArrayList<>();
     ArrayList<Creator> creatorObjects = new ArrayList<>();
     ArrayList<Creator> removeCreatorObjects = new ArrayList<>();
     private final int[][] periodAnim = {
@@ -278,14 +279,13 @@ public class Fairy extends TextureObject {
         int _x = random.nextInt(120) + 70;
         int _y = random.nextInt(160) + 70;
         for (int i = 0; i < 7; i++) {
-            Object object = new Object(texture, 1.0f);
+            final Object object = objects.obtain(texture, 1.0f);
             object.resetMatrix();
             object.resetViewMatrix();
             object.setViewTranslate(_x, height - _y);
             object.index = index;
             object.frameCounter = 0;
             object.animCounter = i;
-            objects.add(object);
         }
     }
 
@@ -314,9 +314,11 @@ public class Fairy extends TextureObject {
 
         updateCreator();
 
-        final int objectsSize = objects.size();
-        for (int i = 0; i < objectsSize; i++) {
-            final Object object = objects.get(i);
+        final ReusableIterator<Object> iterator = objects.iterator();
+        iterator.acquire();
+
+        while (iterator.hasNext()) {
+            final Object object = iterator.next();
             if (object.frameCounter < matrixTransform[object.index].length) {
                 object.resetMatrix();
                 object.setTransform(matrixTransform[object.index][object.frameCounter][object.animCounter]);
@@ -330,14 +332,10 @@ public class Fairy extends TextureObject {
                     }
                 }
                 object.frameCounter++;
-            } else removeObjects.add(object);
+            } else iterator.remove();
         }
 
-        final int removeObjectsSize = removeObjects.size();
-        for (int i = 0; i < removeObjectsSize; i++) {
-            objects.remove(removeObjects.get(i));
-        }
-        removeObjects.clear();
+        iterator.release();
     }
 
     private static class Creator {

--- a/java/com/scrat/everchanging/HeartsScene.java
+++ b/java/com/scrat/everchanging/HeartsScene.java
@@ -33,6 +33,6 @@ public class HeartsScene extends Scene implements Rain.FinishCallback {
 
     @Override
     public void callingFinishCallback(Object object) {
-        ripple.createObject(object);
+        ripple.createObjectCopy(object);
     }
 }

--- a/java/com/scrat/everchanging/Object.java
+++ b/java/com/scrat/everchanging/Object.java
@@ -27,8 +27,9 @@ public class Object {
     private final float[] tmpTransformMatrix = new float[16];
 
     public boolean remove = false;
+    public boolean used;
 
-    private float scale = 1.0f;
+    public float scale = 1.0f;
 
     public FloatBuffer vertexBuffer; //Буффер описания размеров прямоугольника
     public TextureManager.Texture texture;
@@ -44,20 +45,64 @@ public class Object {
     public float yscale = 0;
 
     public float x_scalefactor;
+    public float y_scalefactor;
 
     public float rotation = 0;
     public float[] ViewTranslate = {0.0f, 0.0f};
     public float[] viewTransformMatrix = {1.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f};
     public float[] transformMatrix = {1.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f};
 
-    Object(TextureManager.Texture texture, float scale) {
+    Object() {
         final ByteBuffer objectVerticesBuffer = ByteBuffer.allocateDirect(12 * 4);
         objectVerticesBuffer.order(ByteOrder.nativeOrder());
-
         vertexBuffer = objectVerticesBuffer.asFloatBuffer();
+        resetMatrix();
 
         if (texture != null) setTexture(texture, scale);
-        resetMatrix();
+    }
+
+    Object(TextureManager.Texture texture, float scale) {
+        this();
+        if (texture != null) setTexture(texture, scale);
+    }
+
+    void copyFrom(final Object source) {
+        System.arraycopy(source.modelMatrix, 0, modelMatrix, 0, modelMatrix.length);
+        System.arraycopy(source.viewMatrix, 0, viewMatrix, 0, viewMatrix.length);
+        System.arraycopy(source.matrix, 0, matrix, 0, matrix.length);
+
+        System.arraycopy(source.translateMatrix, 0, translateMatrix, 0, translateMatrix.length);
+        System.arraycopy(source.scaleMatrix, 0, scaleMatrix, 0, scaleMatrix.length);
+        System.arraycopy(source.rotateMatrix, 0, rotateMatrix, 0, rotateMatrix.length);
+        System.arraycopy(source.rotateSkewMatrix, 0, rotateSkewMatrix, 0, rotateSkewMatrix.length);
+
+        System.arraycopy(source.rotateSkewViewMatrix, 0, rotateSkewViewMatrix, 0, rotateSkewViewMatrix.length);
+        System.arraycopy(source.translateViewMatrix, 0, translateViewMatrix, 0, translateViewMatrix.length);
+        System.arraycopy(source.scaleViewMatrix, 0, scaleViewMatrix, 0, scaleViewMatrix.length);
+        System.arraycopy(source.rotateViewMatrix, 0, rotateViewMatrix, 0, rotateViewMatrix.length);
+        System.arraycopy(source.tmpTransformMatrix, 0, tmpTransformMatrix, 0, tmpTransformMatrix.length);
+
+        System.arraycopy(source.ColorTransformValue, 0, ColorTransformValue, 0, ColorTransformValue.length);
+        System.arraycopy(source.ViewColorTransformValue, 0, ViewColorTransformValue, 0, ViewColorTransformValue.length);
+
+        System.arraycopy(source.ViewTranslate, 0, ViewTranslate, 0, ViewTranslate.length);
+        System.arraycopy(source.viewTransformMatrix, 0, viewTransformMatrix, 0, viewTransformMatrix.length);
+        System.arraycopy(source.transformMatrix, 0, transformMatrix, 0, transformMatrix.length);
+
+        texture = source.texture;
+        alpha = source.alpha;
+
+        frameCounter = source.frameCounter;
+        animCounter = source.animCounter;
+        index = source.index;
+
+        xscale = source.xscale;
+        yscale = source.yscale;
+
+        x_scalefactor = source.x_scalefactor;
+        y_scalefactor = source.y_scalefactor;
+
+        rotation = source.rotation;
     }
 
     void setTexture(TextureManager.Texture texture, float scale) {
@@ -174,13 +219,13 @@ public class Object {
         Matrix.setRotateM(rotateMatrix, 0, angle, 0, 0, 1f);
     }
 
-
     void setTranslate(float translateX, float translateY) {
         Matrix.translateM(translateMatrix, 0, translateX, translateY, 0);
     }
 
     void setScale(float scaleX, float scaleY) {
         x_scalefactor = scaleX;
+        y_scalefactor = scaleY;
         Matrix.scaleM(scaleMatrix, 0, scaleX, scaleY, 0);
     }
 

--- a/java/com/scrat/everchanging/ObjectPool.java
+++ b/java/com/scrat/everchanging/ObjectPool.java
@@ -1,0 +1,125 @@
+package com.scrat.everchanging;
+
+import com.scrat.everchanging.util.ReusableIterator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class ObjectPool {
+
+    private final UsedObjectsIterator usedObjectsIterator = new UsedObjectsIterator();
+
+    private final List<Object> all = new ArrayList<>();
+    private int usedObjectCount;
+
+    int objectsInUseCount() {
+        return usedObjectCount;
+    }
+
+    void markAllAsUnused() {
+        final int size = all.size();
+        for (int i = 0; i < size; i++) {
+            final Object object = all.get(i);
+            if (object.used) {
+                object.used = false;
+                usedObjectCount--;
+            }
+        }
+    }
+
+    ReusableIterator<Object> iterator() {
+        usedObjectsIterator.acquire();
+        usedObjectsIterator.reset();
+        usedObjectsIterator.release();
+
+        return usedObjectsIterator;
+    }
+
+    /**
+     * Retrieves unused object from pool or creates a new one and adds it to the pool.
+     */
+    Object obtain() {
+        Object toReturn = nextUnusedOrNull();
+        if (toReturn == null) {
+            toReturn = new Object();
+            all.add(toReturn);
+        }
+
+        if (!toReturn.used) {
+            toReturn.used = true;
+            usedObjectCount++;
+        }
+        return toReturn;
+    }
+
+    /**
+     * Retrieves unused object from pool or creates a new one and adds to the pool, then applies
+     * texture.
+     */
+    Object obtain(final TextureManager.Texture texture, final float scale) {
+        final Object toReturn = obtain();
+        toReturn.setTexture(texture, scale);
+        return toReturn;
+    }
+
+    private Object nextUnusedOrNull() {
+        final int allSize = all.size();
+        for (int i = 0; i < allSize; i++) {
+            final Object object = all.get(i);
+            if (!object.used) {
+                return object;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Unlike a normal Iterator, this one is reusable.<br/><br/>
+     * <p>
+     * Because this will be used heavily on each frame render, we need to avoid creating and
+     * releasing objects. This iterator fulfills this goal.<br/><br/>
+     * <p>
+     * Call {@link #reset} to prepare for using with next client.<br/><br/>
+     * <p>
+     * Calling {@link #remove()} will mark object as unused and keep in the pool.
+     */
+    class UsedObjectsIterator extends ReusableIterator<Object> {
+
+        private int i;
+        private int limit;
+
+        @Override
+        public void reset() {
+            throwIfNotLocked();
+            i = 0;
+            limit = usedObjectCount;
+        }
+
+        @Override
+        public boolean hasNext() {
+            throwIfNotLocked();
+            return i < limit;
+        }
+
+        @Override
+        public Object next() {
+            throwIfNotLocked();
+            while (!all.get(i).used) {
+                i++;
+            }
+            return all.get(i++);
+        }
+
+        /**
+         * Marks as unused instead of actually removing
+         */
+        @Override
+        public void remove() {
+            throwIfNotLocked();
+            all.get(--i).used = false;
+            usedObjectCount--;
+            limit--;
+        }
+    }
+}

--- a/java/com/scrat/everchanging/RainsScene.java
+++ b/java/com/scrat/everchanging/RainsScene.java
@@ -34,6 +34,6 @@ public class RainsScene extends Scene implements Rain.FinishCallback {
 
     @Override
     public void callingFinishCallback(Object object) {
-        ripple.createObject(object);
+        ripple.createObjectCopy(object);
     }
 }

--- a/java/com/scrat/everchanging/Ripple.java
+++ b/java/com/scrat/everchanging/Ripple.java
@@ -1,11 +1,11 @@
 package com.scrat.everchanging;
 
 import android.content.Context;
-import java.util.ArrayList;
+
+import com.scrat.everchanging.util.ReusableIterator;
 
 public class Ripple extends TextureObject  {
     static final String[][] textureList = {{"shape_23","shape_262"}};
-    ArrayList<Object> removeObjects = new ArrayList<>();
     float speedScaleX = 1.3f;
     float speedScaleY = 1.05f;
     int startAplpha = 80;
@@ -17,16 +17,20 @@ public class Ripple extends TextureObject  {
         this.typesAnim = anim;
     }
 
-    public void createObject(Object object) {
-        object.frameCounter = 0;
-        object.setAplpha(startAplpha);
-        objects.add(object);
+    public void createObjectCopy(final Object object) {
+        final Object newObject = objects.obtain();
+        newObject.copyFrom(object);
+
+        newObject.setAplpha(0);
+        newObject.frameCounter = 0;
     }
 
     public void update() {
-        final int objectsSize = objects.size();
-        for (int i = 0; i < objectsSize; i++) {
-            final Object object = objects.get(i);
+        final ReusableIterator<Object> iterator = objects.iterator();
+        iterator.acquire();
+
+        while (iterator.hasNext()) {
+            final Object object = iterator.next();
             if (object.frameCounter > 0) {
                 if (object.frameCounter == 1) {
                     int textureIndex = textureManager.getTextureIndex(textureList[0][typesAnim]);
@@ -37,13 +41,9 @@ public class Ripple extends TextureObject  {
                 object.setAplpha(Math.max((startAplpha - (int) (deltaAplpha * object.frameCounter)), 0));
             }
             object.frameCounter++;
-            if (object.frameCounter > maxFrames) removeObjects.add(object);
+            if (object.frameCounter > maxFrames) iterator.remove();
         }
 
-        final int removeObjectsSize = removeObjects.size();
-        for (int i = 0; i < removeObjectsSize; i++) {
-            objects.remove(removeObjects.get(i));
-        }
-        removeObjects.clear();
+        iterator.release();
     }
 }

--- a/java/com/scrat/everchanging/Scene.java
+++ b/java/com/scrat/everchanging/Scene.java
@@ -2,6 +2,9 @@ package com.scrat.everchanging;
 
 import android.opengl.GLES20;
 import android.opengl.Matrix;
+
+import com.scrat.everchanging.util.ReusableIterator;
+
 public class Scene {
 
     //    public enum Types       {DEFAULT, BACKGROUND, CRYSTALBLICK, FIREFLIES, DANDELIONS, RAIN, BUTTERFLIES, BATS, EYES, FAIRIES, FIREWORKS, HEARTS, LEAVES, PETALS, SNOW, VALENTINES};
@@ -33,7 +36,7 @@ public class Scene {
     }
 
     public void render(TextureObject object) {
-        if (object.objects.size() == 0) return;
+        if (object.objects.objectsInUseCount() == 0) return;
         //Выбираем номер текстуру (почему-то только с 0 работает)
         GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
 
@@ -45,9 +48,11 @@ public class Scene {
         //GLES20.glUniform1i (object.mTexture, GLES20.GL_TEXTURE0);
         float[] sceneMatrix = object.calculateMatrix();
 
-        final int objectsSize = object.objects.size();
-        for (int i = 0; i < objectsSize; i++) {
-            final Object subObject = object.objects.get(i);
+        final ReusableIterator<Object> iterator = object.objects.iterator();
+        iterator.acquire();
+
+        while (iterator.hasNext()) {
+            final Object subObject = iterator.next();
             //Биндим картинку
             GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, subObject.texture.textureID);
             //Активируем позиционирование, что бы это нибыло
@@ -84,6 +89,9 @@ public class Scene {
             //Выключаем позиционирование, что бы это нибыло
 
         }
+
+        iterator.release();
+
         GLES20.glDisableVertexAttribArray(object.mPositionHandle);
         GLES20.glDisableVertexAttribArray(object.mTexCordHandle);
     }

--- a/java/com/scrat/everchanging/TextureObject.java
+++ b/java/com/scrat/everchanging/TextureObject.java
@@ -36,7 +36,8 @@ public class TextureObject {
                     "  gl_FragColor = textureColor;" +
                     "}";
 
-    public final ArrayList<Object> objects = new ArrayList<>();
+    public final ObjectPool objects = new ObjectPool();
+
     public int width;
     public int height;
     public float ratio;

--- a/java/com/scrat/everchanging/Valentine.java
+++ b/java/com/scrat/everchanging/Valentine.java
@@ -2,7 +2,7 @@ package com.scrat.everchanging;
 
 import android.content.Context;
 
-import java.util.ArrayList;
+import com.scrat.everchanging.util.ReusableIterator;
 
 public class Valentine extends TextureObject {
     static final String[][] textureList = {{"image_13","image_15","shape_278","shape_279"}};
@@ -46,7 +46,6 @@ public class Valentine extends TextureObject {
             {30.0f, 31.5f},
             {20.0f, 21.0f}
     };
-    ArrayList<Object> removeObjects = new ArrayList<>();
     float svgScale = 1.0f;
     public Valentine(Context context) {
         super(context, textureList, null);
@@ -60,10 +59,10 @@ public class Valentine extends TextureObject {
             texture.width = sizeTexture[index][0];
             texture.height = sizeTexture[index][1];
             svgScale = 1.0f;
-            object = new Object(texture, svgScale);
+            object = objects.obtain(texture, svgScale);
         } else {
             svgScale = 1.0f / textureManager.dipToPixels(1);
-            object = new Object(texture, 1.0f);
+            object = objects.obtain(texture, 1.0f);
             object.setObjectScale(svgScale);
         }
         float _x = random.nextInt(width);
@@ -75,30 +74,27 @@ public class Valentine extends TextureObject {
         object.setViewRotate(_rotation);
         object.setViewPosition(_x,  _y);
         object.frameCounter = 0;
-        objects.add(object);
-
     }
 
     public void update(boolean createObject) {
 
         if (createObject) createObject();
-        final int objectsSize = objects.size();
-        for (int i = 0; i < objectsSize; i++) {
-            final Object object = objects.get(i);
+
+        final ReusableIterator<Object> iterator = objects.iterator();
+        iterator.acquire();
+
+        while (iterator.hasNext()) {
+            final Object object = iterator.next();
             if (object.frameCounter < matrixTransform.length) {
                 object.resetMatrix();
                 object.setColorTransform(colorTransform[object.frameCounter]);
                 object.setTransform(matrixTransform[object.frameCounter]);
                 object.frameCounter++;
             } else {
-                removeObjects.add(object);
+                iterator.remove();
             }
         }
 
-        final int removeObjectsSize = removeObjects.size();
-        for (int i = 0; i < removeObjectsSize; i++) {
-            objects.remove(removeObjects.get(i));
-        }
-        removeObjects.clear();
+        iterator.release();
     }
 }

--- a/java/com/scrat/everchanging/util/ReusableIterator.java
+++ b/java/com/scrat/everchanging/util/ReusableIterator.java
@@ -1,0 +1,42 @@
+package com.scrat.everchanging.util;
+
+import java.util.Iterator;
+
+/**
+ * Unlike a normal Iterator, this one is reusable.<br/><br/>
+ * <p>
+ * Because this will be used heavily on each frame render, we need to avoid creating and
+ * releasing objects. This iterator fulfills this goal.<br/><br/>
+ * <p>
+ * - MUST call {@link #acquire()} before using;<br/>
+ * - MUST call {@link #release()} after done using.<br/><br/>
+ * <p>
+ * Call {@link #reset()} to start over.<br/><br/>
+ */
+public abstract class ReusableIterator<E> implements Iterator<E> {
+
+    private volatile boolean acquired;
+
+    public abstract void reset();
+
+    public final void acquire() {
+        throwIfLocked();
+        acquired = true;
+    }
+
+    public final void release() {
+        acquired = false;
+    }
+
+    protected final void throwIfNotLocked() {
+        if (!acquired) {
+            throw new IllegalStateException("Call acquire() before using");
+        }
+    }
+
+    protected final void throwIfLocked() {
+        if (acquired) {
+            throw new IllegalStateException("Already acquired");
+        }
+    }
+}


### PR DESCRIPTION
Because allocating objects often and garbage collecting is expensive,
instead of creating and releasing objects to the list of objects, object
pool is used.

Objects in the pool will be marked as either used or unused.
`iterator` will iterate only through the used objects.

To avoid allocating and releasing iterators on every frame, one iterator
will be reused per object pool.

This is the second PR in the series.
I was using memory profiler to detect unnecessary allocations, see changes before commits in 2 PRs and after
[Before.mp4 (Google Drive)](https://drive.google.com/file/d/1MzBWZa60PQ1lNrrTFg6I0KaYrukma9-U/view?usp=drive_link)
[After.mp4 (Google Drive)](https://drive.google.com/file/d/1N2Q6vHhcIQgVm4obj97EMcJDd6hxZchw/view?usp=drive_link)