### PR TITLE
Remove callbacks when not visible

### DIFF
--- a/java/com/scrat/everchanging/Everchanging.java
+++ b/java/com/scrat/everchanging/Everchanging.java
@@ -79,7 +79,7 @@ abstract class EverchangingWallpaperService extends WallpaperService {
         private WallpaperGLSurfaceView glSurfaceView;
         private boolean rendererHasBeenSet;
         private EverchangingRender mRender;
-        boolean paused = false;
+
         private final Handler handler = new Handler();
         private final Runnable mDrawRender = this::doDrawFrame;
 
@@ -98,15 +98,12 @@ abstract class EverchangingWallpaperService extends WallpaperService {
                 if (visible) {
                     glSurfaceView.onResume();
                     gestureDetector = new GestureDetector(getContext(), new GestureListener());
-                    if (paused) mRender.forceUpdateCalendar();
-                    paused = false;
                     doDrawFrame(); // запускаем рендеринг
                 } else {
+                    handler.removeCallbacks(mDrawRender);
                     glSurfaceView.onPause();
                     gestureDetector = null;
-                    paused = true;
                 }
-                mRender.setPause(paused);
             }
         }
 
@@ -114,7 +111,7 @@ abstract class EverchangingWallpaperService extends WallpaperService {
         public void onDestroy() {
             try {
                 super.onDestroy(); //NullPointerException
-                paused = true;
+                handler.removeCallbacks(mDrawRender);
                 glSurfaceView.onDestroy();
                 mRender.onDestroy();
             } catch (Exception ignore) {
@@ -148,7 +145,7 @@ abstract class EverchangingWallpaperService extends WallpaperService {
 
         void doDrawFrame() {
             handler.removeCallbacks(mDrawRender);
-            handler.postDelayed(mDrawRender, 1000 / (paused ? 1 : FPS));
+            handler.postDelayed(mDrawRender, 1000 / FPS);
             glSurfaceView.requestRender();
         }
     }

--- a/java/com/scrat/everchanging/EverchangingRender.java
+++ b/java/com/scrat/everchanging/EverchangingRender.java
@@ -124,8 +124,6 @@ public class EverchangingRender implements GLSurfaceView.Renderer {
 
     private final Context context;
 
-    private boolean pause;
-
     private boolean downTap;
 
     private final ArrayList<Scene> scenes = new ArrayList<>();
@@ -293,20 +291,11 @@ public class EverchangingRender implements GLSurfaceView.Renderer {
         if (SystemClock.uptimeMillis() >=
                 lastCalendarUpdateTimeMillis + UPDATE_CALENDAR_DELAY_MILLIS) {
             lastCalendarUpdateTimeMillis = SystemClock.uptimeMillis();
-            forceUpdateCalendar();
+            calendar.setTimeInMillis(System.currentTimeMillis());
         }
     }
 
-    void forceUpdateCalendar() {
-        calendar.setTimeInMillis(System.currentTimeMillis());
-    }
-
-    void setPause(boolean p) {
-        pause = p;
-    }
-
     void render() {
-        if (pause) return;
         GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);
         //todo draw
         final int scenesSize = scenes.size();


### PR DESCRIPTION
The original fix was introduced because the calendar was updating based on frame count. Since this has changed to timer, we no longer need to schedule Handler messages when not visible.