### PR TITLE
Schedule frames from renderer

### DIFF
--- a/java/com/scrat/everchanging/scheduler/FrameScheduler.java
+++ b/java/com/scrat/everchanging/scheduler/FrameScheduler.java
@@ -1,0 +1,6 @@
+package com.scrat.everchanging.scheduler;
+
+public interface FrameScheduler {
+
+    void scheduleNextFrame(long delayMillis);
+}


### PR DESCRIPTION
To avoid race conditions we must schedule next frame only after previous frame has finished rendering. Otherwise, if you try to schedule faster then it can draw you will get render freezes. This happened when I tried to schedule butterflies at 60 FPS on Emulator. The service was requesting render sooner than old renderings could finish and there was a visible delay of a few seconds for render thread to catch up.

The other problem this solves is inconsistent FPS. If any frame took longer to render it will be accounted for when scheduling next frame.