### PR TITLE
fix-created-objects

### DIFF
--- a/app/src/main/java/com/scrat/everchanging/Bat.java
+++ b/app/src/main/java/com/scrat/everchanging/Bat.java
@@ -221,7 +221,7 @@ final class Bat extends TextureObject {
             {    3.4310f,     3.4320f,     0.0000f,     0.0000f,  2755.2000f,  1152.7000f},
     };
 
-    private static final int MAX_FRAMES = 33;
+    private static final int MAX_FRAMES = 66;
     private static final int NUM_CLIPS = 7;
 
     private int frameCounter;
@@ -263,7 +263,6 @@ final class Bat extends TextureObject {
         object.setViewPosition(_x, _y * ratio);
         object.frameCounter = 0;
         object.animCounter = 0;
-        object.animCounterSkip = false;
         object.index = 0;
     }
 
@@ -281,10 +280,7 @@ final class Bat extends TextureObject {
                 object.setTexture(textureManager.getTexture(textureManager.getTextureIndex(textureList[0][spriteTable[object.animCounter]])), 1.0f);
                 object.setTransform(animateMatrix[object.animCounter]);
                 object.setTransform(matrixTransform[object.frameCounter]);
-                if (!object.animCounterSkip) {
-                    object.animCounter = (object.animCounter + 1) % spriteTable.length;
-                }
-                object.animCounterSkip = !object.animCounterSkip;
+                if (object.frameCounter % 2 == 0) object.animCounter = (object.animCounter + 1) % spriteTable.length;
                 object.frameCounter++;
             } else {
                 if (createObject) resetObject(object);

--- a/app/src/main/java/com/scrat/everchanging/Blick.java
+++ b/app/src/main/java/com/scrat/everchanging/Blick.java
@@ -98,7 +98,6 @@ final class Blick extends TextureObject {
         object.setViewScale(100 * ratio, ratio * 100);
 
         object.animCounter = 0;
-        object.animCounterSkip = false;
         object.frameCounter = 0;
         object.index = index;
         index = (index + 1) % spriteIndex.length;
@@ -108,7 +107,8 @@ final class Blick extends TextureObject {
         object.setTexture(textureManager.getTexture(textureManager.getTextureIndex(textureList[0][(int) animationObjectTransform[object.animCounter][0]])), 1.0f);
         object.setColorTransform(spritesStartColorTransform[object.index]);
         object.setScale(1f, animationObjectTransform[object.animCounter][1]);
-        object.animCounter = (object.animCounter + 1) % animationObjectTransform.length;
+        if (object.frameCounter % 2 == 0) object.animCounter = (object.animCounter + 1) % animationObjectTransform.length;
+
     }
 
     void update(final boolean createObject) {

--- a/app/src/main/java/com/scrat/everchanging/ButterFlie.java
+++ b/app/src/main/java/com/scrat/everchanging/ButterFlie.java
@@ -35,7 +35,7 @@ final class ButterFlie extends TextureObject {
             {{192, 192, 192, 256}, {254, 8, 0, 0}}
     };
 
-    private static final int MAX_FRAMES = 10;
+    private static final int MAX_FRAMES = 20;
 
     private final float[] animationStartPosition = {1.0f, 1.0f, 0.0000f, 0.0000f, 3.40f, -3.60f};
 

--- a/app/src/main/java/com/scrat/everchanging/Crystal.java
+++ b/app/src/main/java/com/scrat/everchanging/Crystal.java
@@ -88,7 +88,7 @@ final class Crystal extends TextureObject {
 
     private static final String[][] textureList = {{"image_13", "image_15"}};
 
-    private static final int MAX_FRAMES = 2;
+    private static final int MAX_FRAMES = 4;
 
     private int frameCounter = 0;
 

--- a/app/src/main/java/com/scrat/everchanging/Dandelion.java
+++ b/app/src/main/java/com/scrat/everchanging/Dandelion.java
@@ -447,7 +447,7 @@ final class Dandelion extends TextureObject {
 
     // @formatter:on
 
-    private static final int MAX_FRAMES = 7;
+    private static final int MAX_FRAMES = 14;
 
     private final float[] animationStartPosition = {0.15f, 0.15f, 0.0000f, 0.0000f, 38.55f, 24.85f};
 
@@ -482,7 +482,6 @@ final class Dandelion extends TextureObject {
         object.setViewPosition(_x, _y);
         object.setColorTransform(animationStartColor[object.index]);
         object.animCounter = 0;
-        object.animCounterSkip = false;
         object.frameCounter = 0;
     }
 
@@ -510,13 +509,8 @@ final class Dandelion extends TextureObject {
             object.setTexture(textureManager.getTexture(textureManager.getTextureIndex(textureList[0][object.animCounter])), 1.0f);
             object.setTransform(animationStartPosition);
             object.setTransform(matrixTransform[object.frameCounter]);
+            if (object.frameCounter % 2 == 0) object.animCounter = (object.animCounter + 1) % textureList[0].length;
             object.frameCounter = (object.frameCounter + 1) % matrixTransform.length;
-
-            if (!object.animCounterSkip) {
-                object.animCounter = (object.animCounter + 1) % textureList[0].length;
-            }
-            object.animCounterSkip = !object.animCounterSkip;
-
             if (!createObject && (object.frameCounter == 0)) iterator.remove();
         }
 

--- a/app/src/main/java/com/scrat/everchanging/Everchanging.java
+++ b/app/src/main/java/com/scrat/everchanging/Everchanging.java
@@ -95,6 +95,7 @@ public final class Everchanging extends WallpaperService {
             if (rendererHasBeenSet) {
                 this.visible = visible;
                 if (visible) {
+                    mRender.forceUpdateCalendar();
                     glSurfaceView.onResume();
                     gestureDetector = new GestureDetector(getContext(), new GestureListener());
                     frameScheduler.scheduleNextFrame(0); // запускаем рендеринг

--- a/app/src/main/java/com/scrat/everchanging/Eye.java
+++ b/app/src/main/java/com/scrat/everchanging/Eye.java
@@ -80,7 +80,6 @@ final class Eye extends TextureObject {
                 break;
         }
         object.animCounter = 0;
-        object.animCounterSkip = false;
 
         final int _yscale = random.nextInt(75) + 50;
         int _xscale = _yscale;

--- a/app/src/main/java/com/scrat/everchanging/FireFlie.java
+++ b/app/src/main/java/com/scrat/everchanging/FireFlie.java
@@ -272,7 +272,7 @@ public class FireFlie extends TextureObject {
     };
     // @formatter:on
 
-    private static final int MAX_FRAMES = 6;
+    private static final int MAX_FRAMES = 12;
 
     private int numClips = minObjects;
     private int frameCounter = 0;

--- a/app/src/main/java/com/scrat/everchanging/Fly.java
+++ b/app/src/main/java/com/scrat/everchanging/Fly.java
@@ -354,7 +354,6 @@ public class Fly extends TextureObject {
         object.setViewTranslate(translate[0], translate[1]);
         object.frameCounter = 0;
         object.animCounter = 0;
-        object.animCounterSkip = false;
         object.index = index;
         object.setScale(xscale == 0 ? 1 : -1, 1);
     }
@@ -374,12 +373,8 @@ public class Fly extends TextureObject {
                 object.setScale(scale, 1);
                 object.setTransform(matrixTransform[object.index][object.frameCounter]);
                 object.setColorTransform(colorTransform);
+                if (object.frameCounter % 2 == 0) object.animCounter = (object.animCounter + 1) % 2;
                 object.frameCounter++;
-
-                if (!object.animCounterSkip) {
-                    object.animCounter = (object.animCounter + 1) % 2;
-                }
-                object.animCounterSkip = !object.animCounterSkip;
             } else {
                 creatorCallback.callingCrystallEndCallback(object.transformMatrix, object.ViewTranslate);
                 iterator.remove();

--- a/app/src/main/java/com/scrat/everchanging/Leave.java
+++ b/app/src/main/java/com/scrat/everchanging/Leave.java
@@ -733,7 +733,7 @@ final class Leave extends TextureObject {
             {{128, 128, 128, 256}, {199, 168, 39, 0}}
     };
 
-    private static final int MAX_FRAMES = 16;
+    private static final int MAX_FRAMES = 32;
 
     private final Calendar calendar;
 
@@ -782,7 +782,6 @@ final class Leave extends TextureObject {
         object.index = animCount;
         object.frameCounter = 0;
         object.animCounter = 0;
-        object.animCounterSkip = false;
         object.remove = false;
     }
 
@@ -816,16 +815,13 @@ final class Leave extends TextureObject {
             }
 
             object.setTransform(AnimatedTextureMatrix[object.index][object.frameCounter]);
-            object.frameCounter = (object.frameCounter + 1) % AnimatedTextureMatrix[object.index].length;
 
-            if (!object.animCounterSkip) {
-                object.animCounter = (object.animCounter + 1) % AnimateTextureList[object.index > 0 ? 1 : 0].length;
-            }
-            object.animCounterSkip = !object.animCounterSkip;
+            if (object.frameCounter % 2 == 0) object.animCounter = (object.animCounter + 1) % AnimateTextureList[object.index > 0 ? 1 : 0].length;
+
+            object.frameCounter = (object.frameCounter + 1) % AnimatedTextureMatrix[object.index].length;
 
             if (object.frameCounter == 0) {
                 object.animCounter = 0;
-                object.animCounterSkip = false;
                 if (--object.index > 0) object.remove = true;
             }
 

--- a/app/src/main/java/com/scrat/everchanging/Petal.java
+++ b/app/src/main/java/com/scrat/everchanging/Petal.java
@@ -678,7 +678,7 @@ final class Petal extends TextureObject {
     };
     // @formatter:on
 
-    private static final int MAX_FRAMES = 16;
+    private static final int MAX_FRAMES = 32;
 
     private final ArrayList<Creator> creatingFramesCounter = new ArrayList<>();
 

--- a/app/src/main/java/com/scrat/everchanging/Rain.java
+++ b/app/src/main/java/com/scrat/everchanging/Rain.java
@@ -33,7 +33,7 @@ final class Rain extends TextureObject {
 
     private static final String[][] textureList = {{"shape_22"}};
 
-    private static final int MAX_FRAMES = 2;
+    private static final int MAX_FRAMES = 4;
     private static final float SPEED = 320.0f / 7.0f / 2;
 
     private final Calendar calendar;

--- a/app/src/main/java/com/scrat/everchanging/Snow.java
+++ b/app/src/main/java/com/scrat/everchanging/Snow.java
@@ -230,7 +230,7 @@ final class Snow extends TextureObject {
 
     // @formatter:on
 
-    private static final int MAX_FRAMES = 8;
+    private static final int MAX_FRAMES = 16;
 
     private final Calendar calendar;
 
@@ -283,7 +283,6 @@ final class Snow extends TextureObject {
         object.setAplpha((int) (_yscale * 4.5f));
         object.frameCounter = 0;
         object.animCounter = 0;
-        object.animCounterSkip = false;
     }
 
     void update(final boolean createObject) {


### PR DESCRIPTION
1. When we increase FPS, the MAX_FRAMES variable is also incremented 2 times faster. It is mainly needed to control the speed of creating new animation objects. Therefore, its value must be increased by 2 times, otherwise there will be too many objects.
2. I also returned ForceUpdateCalendar when the screen is turned on, after all, it gives a result with frequent time changes (as an option during testing)
3. In some animations, I changed the way I skip texture changes. like in https://github.com/SCratORS/Everchanging/pull/30

P.S. While there are still questions with Fairy (there are complex animations), FireWork and Eye - 20 FPS (When switching to them from 40 FPS, they work faster than necessary for a while)