### PR TITLE
Skip frames when scene transitioning

### DIFF
--- a/app/src/main/java/com/scrat/everchanging/EverchangingRender.java
+++ b/app/src/main/java/com/scrat/everchanging/EverchangingRender.java
@@ -175,19 +175,19 @@ final class EverchangingRender implements GLSurfaceView.Renderer {
 
 
         scenes.add(new BackgroundScene(context, calendar));
-        scenes.add(new CrystalBlickScene(context));
-        scenes.add(new FireFliesScene(context, calendar));
-        scenes.add(new DandelionsScene(context, calendar));
-        scenes.add(new RainsScene(context, calendar));
-        scenes.add(new PetalsScene(context));
-        scenes.add(new SnowsScene(context, calendar));
-        scenes.add(new LeavesScene(context, calendar));
-        scenes.add(new ButterFliesScene(context, calendar));
         scenes.add(new BatsScene(context));
-        scenes.add(new HeartsScene(context, calendar));
-        scenes.add(new ValentinesScene(context));
+        scenes.add(new ButterFliesScene(context, calendar));
+        scenes.add(new CrystalBlickScene(context));
+        scenes.add(new DandelionsScene(context, calendar));
         scenes.add(new FairiesScene(context));
+        scenes.add(new FireFliesScene(context, calendar));
+        scenes.add(new HeartsScene(context, calendar));
+        scenes.add(new LeavesScene(context, calendar));
+        scenes.add(new PetalsScene(context));
+        scenes.add(new RainsScene(context, calendar));
+        scenes.add(new SnowsScene(context, calendar));
         scenes.add(new TouchBlickScene(context));
+        scenes.add(new ValentinesScene(context));
         // Scenes running at 20 fps must be last, because they rely on maxFps calculation
         scenes.add(new EyesScene(context, calendar));
         scenes.add(new FireWorksScene(context, calendar));
@@ -257,64 +257,64 @@ final class EverchangingRender implements GLSurfaceView.Renderer {
                     ((BackgroundScene) scene).update();
                     break;
 
-                case CB:
-                    ((CrystalBlickScene) scene).update(createObject);
-                    break;
-
-                case FF:
-                    ((FireFliesScene) scene).update(createObject);
-                    break;
-
-                case D:
-                    ((DandelionsScene) scene).update(createObject);
-                    break;
-
-                case R:
-                    ((RainsScene) scene).update(createObject);
-                    break;
-
-                case P:
-                    ((PetalsScene) scene).update(createObject);
-                    break;
-
-                case S:
-                    ((SnowsScene) scene).update(createObject);
-                    break;
-
-                case L:
-                    ((LeavesScene) scene).update(createObject);
-                    break;
-
-                case FW:
-                    ((FireWorksScene) scene).update(createObject, lastSceneMaxFps);
-                    break;
-
-                case E:
-                    ((EyesScene) scene).update(createObject, lastSceneMaxFps);
+                case BA:
+                    ((BatsScene) scene).update(createObject);
                     break;
 
                 case B:
                     ((ButterFliesScene) scene).update(createObject);
                     break;
 
-                case BA:
-                    ((BatsScene) scene).update(createObject);
+                case CB:
+                    ((CrystalBlickScene) scene).update(createObject);
                     break;
 
-                case H:
-                    ((HeartsScene) scene).update(createObject);
+                case D:
+                    ((DandelionsScene) scene).update(createObject);
                     break;
 
-                case V:
-                    ((ValentinesScene) scene).update(createObject);
+                case E:
+                    ((EyesScene) scene).update(createObject, lastSceneMaxFps);
                     break;
 
                 case F:
                     ((FairiesScene) scene).update(createObject);
                     break;
 
+                case FF:
+                    ((FireFliesScene) scene).update(createObject);
+                    break;
+
+                case FW:
+                    ((FireWorksScene) scene).update(createObject, lastSceneMaxFps);
+                    break;
+
+                case H:
+                    ((HeartsScene) scene).update(createObject);
+                    break;
+
+                case L:
+                    ((LeavesScene) scene).update(createObject);
+                    break;
+
+                case P:
+                    ((PetalsScene) scene).update(createObject);
+                    break;
+
+                case R:
+                    ((RainsScene) scene).update(createObject);
+                    break;
+
+                case S:
+                    ((SnowsScene) scene).update(createObject);
+                    break;
+
                 case TB:
                     ((TouchBlickScene) scene).update(downTap, posX, posY);
+                    break;
+
+                case V:
+                    ((ValentinesScene) scene).update(createObject);
                     break;
             }
         }

--- a/app/src/main/java/com/scrat/everchanging/EverchangingRender.java
+++ b/app/src/main/java/com/scrat/everchanging/EverchangingRender.java
@@ -2,7 +2,6 @@ package com.scrat.everchanging;
 
 import static com.scrat.everchanging.Scene.ShortTypes.B;
 import static com.scrat.everchanging.Scene.ShortTypes.BA;
-import static com.scrat.everchanging.Scene.ShortTypes.BG;
 import static com.scrat.everchanging.Scene.ShortTypes.CB;
 import static com.scrat.everchanging.Scene.ShortTypes.D;
 import static com.scrat.everchanging.Scene.ShortTypes.E;
@@ -212,12 +211,22 @@ final class EverchangingRender implements GLSurfaceView.Renderer {
 
         final int scenesSize = scenes.size();
         for (int i = 0; i < scenesSize; i++) {
-            scenes.get(i).setupPosition(
-                    surfaceWidth,
-                    surfaceHeight,
-                    (i < scenesSize - 1) ? scaleImageHeight : scaleImageWidth,
-                    displayRotation
-            );
+            final Scene scene = scenes.get(i);
+            if (scene.sceneType == Scene.ShortTypes.TB) {
+                scene.setupPosition(
+                        surfaceWidth,
+                        surfaceHeight,
+                        scaleImageWidth,
+                        displayRotation
+                );
+            } else {
+                scene.setupPosition(
+                        surfaceWidth,
+                        surfaceHeight,
+                        scaleImageHeight,
+                        displayRotation
+                );
+            }
         }
     }
 

--- a/app/src/main/java/com/scrat/everchanging/EverchangingRender.java
+++ b/app/src/main/java/com/scrat/everchanging/EverchangingRender.java
@@ -182,14 +182,15 @@ final class EverchangingRender implements GLSurfaceView.Renderer {
         scenes.add(new PetalsScene(context));
         scenes.add(new SnowsScene(context, calendar));
         scenes.add(new LeavesScene(context, calendar));
-        scenes.add(new FireWorksScene(context, calendar));
-        scenes.add(new EyesScene(context, calendar));
         scenes.add(new ButterFliesScene(context, calendar));
         scenes.add(new BatsScene(context));
         scenes.add(new HeartsScene(context, calendar));
         scenes.add(new ValentinesScene(context));
         scenes.add(new FairiesScene(context));
         scenes.add(new TouchBlickScene(context));
+        // Scenes running at 20 fps must be last, because they rely on maxFps calculation
+        scenes.add(new EyesScene(context, calendar));
+        scenes.add(new FireWorksScene(context, calendar));
 
         GLES20.glReleaseShaderCompiler();
     }
@@ -285,11 +286,11 @@ final class EverchangingRender implements GLSurfaceView.Renderer {
                     break;
 
                 case FW:
-                    ((FireWorksScene) scene).update(createObject);
+                    ((FireWorksScene) scene).update(createObject, lastSceneMaxFps);
                     break;
 
                 case E:
-                    ((EyesScene) scene).update(createObject);
+                    ((EyesScene) scene).update(createObject, lastSceneMaxFps);
                     break;
 
                 case B:

--- a/app/src/main/java/com/scrat/everchanging/Eye.java
+++ b/app/src/main/java/com/scrat/everchanging/Eye.java
@@ -21,6 +21,7 @@ final class Eye extends TextureObject {
 
     private int numClips;
     private int frameCounter = 0;
+    private int internalCounter;
 
     private final float scale = 0.25f;
     private boolean init = false;
@@ -118,7 +119,12 @@ final class Eye extends TextureObject {
         object.setViewPosition(_x, height - 320 + _y);
     }
 
-    void update(final boolean createObject) {
+    void update(final boolean createObject, final boolean skipEverySecondFrame) {
+        internalCounter++;
+        if (skipEverySecondFrame && internalCounter % 2 == 0) {
+            return;
+        }
+
         frameCounter = (frameCounter + 1) % MAX_FRAMES;
         if (!init && createObject) numClips = get0601() ? 10 : (random.nextInt(5) + 5);
         init = createObject;

--- a/app/src/main/java/com/scrat/everchanging/EyesScene.java
+++ b/app/src/main/java/com/scrat/everchanging/EyesScene.java
@@ -18,8 +18,8 @@ final class EyesScene extends Scene {
         return eye.objects.objectsInUseCount() != 0;
     }
 
-    public void update(boolean createObject) {
-        eye.update(createObject);
+    public void update(final boolean createObject, final int actualFps) {
+        eye.update(createObject, getFps() * 2 == actualFps);
     }
 
     @Override

--- a/app/src/main/java/com/scrat/everchanging/FireWork.java
+++ b/app/src/main/java/com/scrat/everchanging/FireWork.java
@@ -27,11 +27,13 @@ public class FireWork extends TextureObject {
             {{0, 0, 0, 256}, {221, 66, 0, 0}}
     };
 
-    int numClips = minObjects;
-    float svgScale = 1.0f;
-    int frameCounter = 0;
-    boolean init = false;
-    int maxFrames = 5;
+    private static final int MAX_FRAMES = 5;
+
+    private int numClips = minObjects;
+    private float svgScale = 1.0f;
+    private int frameCounter;
+    private int internalCounter;
+    private boolean init;
 
     private final Calendar calendar;
 
@@ -86,8 +88,13 @@ public class FireWork extends TextureObject {
         object.index = random.nextInt(5);
     }
 
-    public void update(boolean createObject) {
-        frameCounter = (frameCounter + 1) % maxFrames;
+    public void update(final boolean createObject, final boolean skipEverySecondFrame) {
+        internalCounter++;
+        if (skipEverySecondFrame && internalCounter % 2 == 0) {
+            return;
+        }
+
+        frameCounter = (frameCounter + 1) % MAX_FRAMES;
         if (!init && createObject)
             numClips = (get010104() ? maxObjects : (minObjects + random.nextInt(maxObjects - 4)));
         init = createObject;

--- a/app/src/main/java/com/scrat/everchanging/FireWorksScene.java
+++ b/app/src/main/java/com/scrat/everchanging/FireWorksScene.java
@@ -29,8 +29,8 @@ final class FireWorksScene extends Scene {
         firework.setupPosition(width, height, ratio);
     }
 
-    public void update(boolean createObject) {
-        firework.update(createObject);
+    public void update(final boolean createObject,final int actualFps) {
+        firework.update(createObject, getFps() * 2 == actualFps);
     }
 
     @Override

--- a/app/src/main/java/com/scrat/everchanging/TouchBlickScene.java
+++ b/app/src/main/java/com/scrat/everchanging/TouchBlickScene.java
@@ -18,8 +18,7 @@ final class TouchBlickScene extends Scene {
 
     @Override
     public boolean hasObjectsInUse() {
-        // Always return false so that TouchBlick visibility does not affect other scenes FPS
-        return false;
+        return touchBlick.objects.objectsInUseCount() != 0;
     }
 
     public void update(final boolean createObject, final float posX, final float posY) {


### PR DESCRIPTION
There are multiple commits:
1. Make TouchBlick order in list independent;
2. Actual change: when transitioning between scenes with 20 and 40 fps, skip frames for 20 fps scenes;
3. Nice to have: alphabetical ordering of scenes.