### PR TITLE
Remove dpToPixels

### DIFF
--- a/app/src/main/java/com/scrat/everchanging/TextureManager.java
+++ b/app/src/main/java/com/scrat/everchanging/TextureManager.java
@@ -81,8 +81,8 @@ final class TextureManager {
             final Drawable drawable = context.getDrawable(textures[counter].textureResId);
             if (drawable instanceof BitmapDrawable) {
                 picture = ((BitmapDrawable) drawable).getBitmap();
-                textures[counter].width = picture.getWidth() / dipToPixels(1);
-                textures[counter].height = picture.getHeight() / dipToPixels(1);
+                textures[counter].width = picture.getWidth();
+                textures[counter].height = picture.getHeight();
             } else if (drawable instanceof VectorDrawable) {
                 picture = Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
                 final Canvas canvas = new Canvas(picture);


### PR DESCRIPTION
dpToPixels needs to be removed.

With dpToPixels (main):

Pixel 7 Pro. `main` (left) vs `remove-dp-to-pixels` (right)
<img src="https://github.com/SCratORS/Everchanging/assets/6018890/d1605837-974d-4147-bbc6-5a3e884c8cc0" width="200"/>&nbsp;&nbsp;<img src="https://github.com/SCratORS/Everchanging/assets/6018890/11b2b95c-68f4-45a8-8af8-775033b708e8" width="200"/>

Nexus S (480x800). `main` (left) vs `remove-dp-to-pixels` (right)
<img src="https://github.com/SCratORS/Everchanging/assets/6018890/8910d7df-a346-416d-95db-146a70b05e1d" width="200"/>&nbsp;&nbsp;<img src="https://github.com/SCratORS/Everchanging/assets/6018890/7dbca243-42f4-4582-a7ef-79b6c26cae0c" width="200"/>
