### PR TITLE
Fix Background texture scale on resize was not applied

### DIFF
--- a/app/src/main/java/com/scrat/everchanging/Background.java
+++ b/app/src/main/java/com/scrat/everchanging/Background.java
@@ -242,6 +242,7 @@ final class Background extends TextureObject {
     }
 
     private void setObjectScaleAndTranslation(final Object object) {
+        object.setTexture(object.texture, scale);
         object.setObjectScale(1.0f);
         object.resetMatrix();
         object.resetViewMatrix();


### PR DESCRIPTION
On the screenshot you can also observe the issue with leave positions on wide screens, this is a separate issue which I fixed at #54,

Before:
![Before](https://github.com/SCratORS/Everchanging/assets/6018890/f4906668-cd0b-46f7-837d-cfd1f3c3e4f4)

After:
![After](https://github.com/SCratORS/Everchanging/assets/6018890/0a1f14d3-8371-4244-996f-44ac61ac8d71)

